### PR TITLE
Changed tests to properly initialize sensors

### DIFF
--- a/bsi0007-tilt-sensor/tests/main.cpp
+++ b/bsi0007-tilt-sensor/tests/main.cpp
@@ -5,14 +5,15 @@
 
 using namespace wlp;
 
+auto sensor = BSI0007::TiltSensor(Board::A0);
+
 void setup() {
     uart.begin(9600);
     trace.begin(&uart);
+    sensor.begin();
 }
 
 void loop() {
-    static auto sensor = BSI0007::TiltSensor(Board::A0);
-
     trace << "\r";  // Move cursor to start of line
     trace << sensor.read_value() << "° tilt";
     delay(100);

--- a/bsp008z-pressure-sensor/tests/main.cpp
+++ b/bsp008z-pressure-sensor/tests/main.cpp
@@ -5,14 +5,15 @@
 
 using namespace wlp;
 
+auto sensor = BSP008Z::PressureSensor(Board::A0);
+
 void setup() {
     uart.begin(9600);
     trace.begin(&uart);
+    sensor.begin();
 }
 
 void loop() {
-    static auto sensor = BSP008Z::PressureSensor(Board::A0);
-
     trace << "\r";  // Move cursor to start of line
     trace << sensor.read_value() << " bar";
     delay(100);

--- a/cosa-analog-pin-reader/tests/main.cpp
+++ b/cosa-analog-pin-reader/tests/main.cpp
@@ -5,14 +5,15 @@
 
 using namespace wlp;
 
+auto reader = AnalogPinReader(Board::A0);
+
 void setup() {
     uart.begin(9600);
     trace.begin(&uart);
+    reader.begin();
 }
 
 void loop() {
-    static auto reader = AnalogPinReader(Board::A0);
-
     trace << "\r";  // Move cursor to start of line
     trace << reader.read_value() << " V";
     delay(100);

--- a/tmp36-temperature-sensor/tests/main.cpp
+++ b/tmp36-temperature-sensor/tests/main.cpp
@@ -5,14 +5,15 @@
 
 using namespace wlp;
 
+auto sensor = TMP36::TemperatureSensor(Board::A0);
+
 void setup() {
     uart.begin(9600);
     trace.begin(&uart);
+    sensor.begin();
 }
 
 void loop() {
-    static auto sensor = TMP36::TemperatureSensor(Board::A0);
-
     trace << "\r";  // Move cursor to start of line
     trace << sensor.read_value() << "°C";
     delay(100);


### PR DESCRIPTION
Realized while testing something today that I haven't been calling `.begin()` on sensors in the tests. This is now fixed.